### PR TITLE
Adjust WebRTC video capture and expose EGL context

### DIFF
--- a/app/src/main/java/com/techm/duress/core/webrtc/WebRTCClient.kt
+++ b/app/src/main/java/com/techm/duress/core/webrtc/WebRTCClient.kt
@@ -49,6 +49,8 @@ class WebRTCClient(
             .createPeerConnectionFactory()
     }
 
+    fun getEglBase(): EglBase = eglBase
+
     fun initialize(answerMode: Boolean = false) {
         CoroutineScope(Dispatchers.Default).launch {
             val iceServers = listOf(
@@ -136,6 +138,7 @@ class WebRTCClient(
 
     fun startLocalVideo(context: Context) {
         localVideoSource = peerConnectionFactory.createVideoSource(false)
+        localVideoSource?.adaptOutputFormat(640, 360, 15)
 
         surfaceTextureHelper = SurfaceTextureHelper.create("CaptureThread", eglBase.eglBaseContext)
         try {
@@ -146,13 +149,17 @@ class WebRTCClient(
         }
 
         videoCapturer?.initialize(surfaceTextureHelper, context, localVideoSource?.capturerObserver)
-        videoCapturer?.startCapture(1280, 720, 15)
+        videoCapturer?.startCapture(640, 360, 15)
 
         localVideoTrack = peerConnectionFactory.createVideoTrack("video_track", localVideoSource)
         localVideoTrack?.setEnabled(true)
 
         peerConnection?.addTrack(localVideoTrack)
         Log.d("WebRTCClient", "Local video track started")
+    }
+
+    fun registerLocalRenderer(renderer: VideoSink) {
+        localVideoTrack?.addSink(renderer)
     }
 
     fun stopLocalVideo() {


### PR DESCRIPTION
## Summary
- Limit local camera capture to 640x360@15fps and match output format
- Allow UI components to register local video renderers
- Provide getter to share the WebRTC EGL context

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b029702348322879efc949c886724