### PR TITLE
Avoid endless WebRTC renegotiation

### DIFF
--- a/app/src/main/java/com/techm/duress/core/webrtc/WebRTCClient.kt
+++ b/app/src/main/java/com/techm/duress/core/webrtc/WebRTCClient.kt
@@ -99,8 +99,7 @@ class WebRTCClient(
                     override fun onRemoveStream(p0: MediaStream?) {}
                     override fun onDataChannel(p0: DataChannel?) {}
                     override fun onRenegotiationNeeded() {
-                        Log.d("WebRTCClient", "Renegotiation needed")
-                        createOffer()
+                        Log.d("WebRTCClient", "Renegotiation needed; ignoring to avoid loop")
                     }
 
                     override fun onConnectionChange(newState: PeerConnection.PeerConnectionState?) {


### PR DESCRIPTION
## Summary
- log onRenegotiationNeeded without creating new offer to prevent renegotiation loop

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b034ad8a88322807f900318933943